### PR TITLE
Update readme and change install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ Set of tools to improve my own experience using SSMS
 
 ## Tools
 - Multi Db Query runner
+
+
 [Demo](https://github.com/user-attachments/assets/cfe159fe-98b8-4e32-861d-cbc3b4f20214)
 
 Generates a query to be executed in the selected databases of the server
 
 # Setup
-- Download the latest VSIX file
+- Download the latest zip file with the content
 - Go to your install path and its `Extensions` subfolder (for example: `C:\Program Files (x86)\Microsoft SQL Server Management Studio 20\Common7\IDE\Extensions`)
 - Create a `SSMSTools` folder
-- Paste the vsix file
+- Paste the content of the zip file inside the folder
 
 ## Development
 ### Requirements

--- a/src/SSMSTools/source.extension.vsixmanifest
+++ b/src/SSMSTools/source.extension.vsixmanifest
@@ -5,8 +5,9 @@
         <DisplayName>SSMSTools</DisplayName>
         <Description xml:space="preserve">Tools to improve SSMS</Description>
     </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0)" />
+    <Installation AllUsers="true">
+        <InstallationTarget Version="[15.0,20.2)" Id="SQL Server Management Studio" />
+        <InstallationTarget Id="ssms" Version="[15.0, 20.2)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Changes the install target to SSMS and fix the readme, indicating that the whole zip needs to be copied over, not only de VSIX file.

Fixes https://github.com/Aztic/SSMS-Tools/issues/6