### PR TITLE
Move commands to context menu

### DIFF
--- a/src/SSMSTools/Commands/MultiDbQueryRunner/MultiDbQueryRunnerCommand.cs
+++ b/src/SSMSTools/Commands/MultiDbQueryRunner/MultiDbQueryRunnerCommand.cs
@@ -89,7 +89,7 @@ namespace SSMSTools.Commands.MultiDbQueryRunner
             // the UI thread.
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
 
-            OleMenuCommandService commandService = await package.GetServiceAsync((typeof(IMenuCommandService))) as OleMenuCommandService;
+            OleMenuCommandService commandService = (OleMenuCommandService)await package.GetServiceAsync((typeof(IMenuCommandService)));
             Instance = new MultiDbQueryRunnerCommand(package, commandService);
         }
 

--- a/src/SSMSTools/SSMSToolsPackage.vsct
+++ b/src/SSMSTools/SSMSToolsPackage.vsct
@@ -45,20 +45,6 @@
     <!--This section defines the elements the user can interact with, like a menu command or a button
         or combo box in a toolbar. -->
     <Buttons>
-      <!--To define a menu group you have to specify its ID, the parent menu and its display priority.
-          The command is visible and enabled by default. If you need to change the visibility, status, etc, you can use
-          the CommandFlag node.
-          You can add more than one CommandFlag node e.g.:
-              <CommandFlag>DefaultInvisible</CommandFlag>
-              <CommandFlag>DynamicVisibility</CommandFlag>
-          If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidSSMSToolsPackageCmdSet" id="MultiDbQueryRunnerId" priority="0x0100" type="Button">
-        <Parent guid="guidSSMSToolsPackageCmdSet" id="MyMenuGroup" />
-        <Icon guid="guidImages" id="bmpPic1" />
-        <Strings>
-          <ButtonText>Run query in multiple Databases</ButtonText>
-        </Strings>
-      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->


### PR DESCRIPTION
Solves https://github.com/Aztic/SSMS-Tools/issues/5

Moves the command to the context menu of the ObjectExplorer. The logic is contained in the package class. An autoload attribute was added so the package loads when SSMS starts.

![ssms_tools_context_menu](https://github.com/user-attachments/assets/c35cacd2-081a-40fd-98fb-85f124187f71)

The command was removed from the 'Tools' menu

